### PR TITLE
Small Fixes

### DIFF
--- a/src/synthid_text/logits_processing.py
+++ b/src/synthid_text/logits_processing.py
@@ -270,7 +270,7 @@ class SynthIDLogitsProcessor(transformers.LogitsProcessor):
       ])
 
     device = scores.device
-    if device != self.device:
+    if str(device) != str(self.device):
       raise ValueError(
           "SynthIDLogitsProcessor received inputs with unexpected device.",
       )

--- a/src/synthid_text/logits_processing_test.py
+++ b/src/synthid_text/logits_processing_test.py
@@ -93,7 +93,6 @@ def test_mean_g_value_matches_theoretical(
   )
 
   probs = torch.nn.functional.softmax(updated_scores, dim=1)
-  generator = torch.Generator(device=device).manual_seed(0)
   next_tokens = torch.multinomial(
       probs,
       num_samples=1,

--- a/src/synthid_text/synthid_mixin.py
+++ b/src/synthid_text/synthid_mixin.py
@@ -208,7 +208,10 @@ class SynthIDSparseTopKMixin(transformers.GenerationMixin):
           "`do_sample` is set to `True`, `logits_warper` must be a"
           f" `LogitsProcessorList` instance (it is {logits_warper})."
       )
-
+    if has_eos_stopping_criteria and not pad_token_id:
+      raise ValueError(
+          "`stopping_criteria` is not empty, `pad_token_id` must be set in generation_config."
+      )
     # init attention / hidden states / scores tuples
     scores = () if (return_dict_in_generate and output_scores) else None
     raw_logits = () if (return_dict_in_generate and output_logits) else None


### PR DESCRIPTION
This PR makes the following changes:

* Update device checking to first cast device to string. The current implementation fails if `device` or `self.device` is `device(type='cpu')` and the other is `cpu` because `device(type='cpu') != 'cpu'`. The same is true for `cuda` or other valid device names`.
* Removed unused generator object in `logits_processing_test.py`. The random generator is instantiated earlier in the test.
* Raise a `ValueError` if `pad_token_id` is not set in the huggingface model's generation_config but early stopping criteria is passed. Some llama3 configs on huggingface do not ship with a `pad_token_id` set